### PR TITLE
only provide the `gen` bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "author": "Chris Manson <chris@manson.ie>",
   "type": "module",
   "bin": {
-    "g": "./bin/gen.js",
-    "gen": "./bin/gen.js",
-    "generate": "./bin/gen.js"
+    "gen": "./bin/gen.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This allows us to run `npx layer-gen` because it only has one script defined. I would love to provide the aliases that I'm removing here but I don't want people to have to define which bin script via an arg when you're running `npx` 